### PR TITLE
feat: Task 9 - Authentication Service

### DIFF
--- a/src/repositories/IUserRepository.ts
+++ b/src/repositories/IUserRepository.ts
@@ -1,0 +1,31 @@
+export interface User {
+  id: number;
+  email: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateUserRequest {
+  email: string;
+  password: string;
+}
+
+/**
+ * User repository interface for data persistence operations
+ */
+export interface IUserRepository {
+  /**
+   * Find user by email address
+   * @param email - User email to search for
+   * @returns Promise resolving to user or null if not found
+   */
+  findByEmail(email: string): Promise<User | null>;
+
+  /**
+   * Create a new user
+   * @param userData - User data for creation
+   * @returns Promise resolving to created user
+   */
+  create(userData: CreateUserRequest): Promise<User>;
+}

--- a/src/security/IJWTHandler.ts
+++ b/src/security/IJWTHandler.ts
@@ -1,0 +1,23 @@
+export interface JWTPayload {
+  userId: number;
+  email: string;
+}
+
+/**
+ * JWT handler interface for token operations
+ */
+export interface IJWTHandler {
+  /**
+   * Generate a JWT token for authenticated user
+   * @param payload - User data to include in token
+   * @returns Promise resolving to signed JWT token
+   */
+  generateToken(payload: JWTPayload): Promise<string>;
+
+  /**
+   * Verify and decode a JWT token
+   * @param token - JWT token to verify
+   * @returns Promise resolving to decoded payload
+   */
+  verifyToken(token: string): Promise<JWTPayload>;
+}

--- a/src/security/IPasswordHasher.ts
+++ b/src/security/IPasswordHasher.ts
@@ -1,0 +1,19 @@
+/**
+ * Password hashing interface for secure password storage
+ */
+export interface IPasswordHasher {
+  /**
+   * Hash a plain text password
+   * @param password - Plain text password to hash
+   * @returns Promise resolving to hashed password
+   */
+  hash(password: string): Promise<string>;
+
+  /**
+   * Verify a plain text password against a hash
+   * @param password - Plain text password to verify
+   * @param hash - Stored password hash
+   * @returns Promise resolving to true if password matches
+   */
+  verify(password: string, hash: string): Promise<boolean>;
+}

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,121 +1,79 @@
-import bcrypt from 'bcrypt';
-import { IUserRepository } from '../repositories/IUserRepository';
-import { IJWTHandler } from '../security/IJWTHandler';
-import { IPasswordHasher } from '../security/IPasswordHasher';
-
-interface RegisterRequest {
-  email: string;
-  password: string;
-}
-
-interface LoginRequest {
-  email: string;
-  password: string;
-}
-
-interface RegisterResponse {
-  id: number;
-}
-
-interface LoginResponse {
-  token: string;
-}
-
-export class AuthServiceError extends Error {
-  public readonly code: string;
-  
-  constructor(message: string, code: string) {
-    super(message);
-    this.code = code;
-  }
-}
+import { IUserRepository } from '../repositories/interfaces/IUserRepository';
+import { IPasswordHasher } from '../security/interfaces/IPasswordHasher';
+import { IJwtHandler } from '../security/interfaces/IJwtHandler';
+import { User } from '../models/User';
+import { ConflictError, UnauthorizedError } from '../errors/AppErrors';
 
 /**
- * Authentication service handling user registration and login business logic
+ * Authentication service handling user registration and login operations
  */
 export class AuthService {
-  private readonly userRepository: IUserRepository;
-  private readonly passwordHasher: IPasswordHasher;
-  private readonly jwtHandler: IJWTHandler;
-
+  /**
+   * Creates an instance of AuthService
+   * @param userRepository - Repository for user data operations
+   * @param passwordHasher - Service for password hashing
+   * @param jwtHandler - Service for JWT token operations
+   */
   constructor(
-    userRepository: IUserRepository,
-    passwordHasher: IPasswordHasher,
-    jwtHandler: IJWTHandler
-  ) {
-    this.userRepository = userRepository;
-    this.passwordHasher = passwordHasher;
-    this.jwtHandler = jwtHandler;
-  }
+    private readonly userRepository: IUserRepository,
+    private readonly passwordHasher: IPasswordHasher,
+    private readonly jwtHandler: IJwtHandler
+  ) {}
 
   /**
-   * Register a new user with email uniqueness validation
-   * @param request - Registration request containing email and password
-   * @returns Promise resolving to user ID
-   * @throws AuthServiceError for validation errors or duplicate email
+   * Registers a new user with email uniqueness validation
+   * @param email - User's email address
+   * @param password - User's plain text password
+   * @returns Promise resolving to created user's ID
+   * @throws ConflictError if email already exists
    */
-  async register(request: RegisterRequest): Promise<RegisterResponse> {
+  async register(email: string, password: string): Promise<number> {
     try {
-      // Check if email already exists
-      const existingUser = await this.userRepository.findByEmail(request.email);
+      const existingUser = await this.userRepository.findByEmail(email);
       if (existingUser) {
-        throw new AuthServiceError('Email already registered', 'DUPLICATE_EMAIL');
+        throw new ConflictError('Email already registered');
       }
 
-      // Hash password before storage
-      const hashedPassword = await this.passwordHasher.hash(request.password);
-
-      // Create user
-      const user = await this.userRepository.create({
-        email: request.email,
-        password: hashedPassword
-      });
-
-      return { id: user.id };
+      const hashedPassword = await this.passwordHasher.hash(password);
+      
+      const user = new User(email, hashedPassword);
+      const createdUser = await this.userRepository.create(user);
+      
+      return createdUser.id!;
     } catch (error) {
-      if (error instanceof AuthServiceError) {
+      if (error instanceof ConflictError) {
         throw error;
       }
-      throw new AuthServiceError('Registration failed', 'REGISTRATION_ERROR');
+      throw new Error(`Registration failed: ${error}`);
     }
   }
 
   /**
-   * Authenticate user credentials and generate JWT token
-   * @param request - Login request containing email and password
+   * Authenticates user credentials and generates JWT token
+   * @param email - User's email address
+   * @param password - User's plain text password
    * @returns Promise resolving to JWT token
-   * @throws AuthServiceError for invalid credentials
+   * @throws UnauthorizedError if credentials are invalid
    */
-  async login(request: LoginRequest): Promise<LoginResponse> {
+  async login(email: string, password: string): Promise<string> {
     try {
-      // Find user by email
-      const user = await this.userRepository.findByEmail(request.email);
+      const user = await this.userRepository.findByEmail(email);
       if (!user) {
-        throw new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS');
+        throw new UnauthorizedError('Invalid credentials');
       }
 
-      // Verify password
-      const isValidPassword = await this.passwordHasher.verify(
-        request.password,
-        user.password
-      );
-      
-      if (!isValidPassword) {
-        throw new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS');
+      const isPasswordValid = await this.passwordHasher.verify(password, user.password);
+      if (!isPasswordValid) {
+        throw new UnauthorizedError('Invalid credentials');
       }
 
-      // Generate JWT token
-      const token = await this.jwtHandler.generateToken({
-        userId: user.id,
-        email: user.email
-      });
-
-      return { token };
+      const token = this.jwtHandler.generateToken({ userId: user.id!, email: user.email });
+      return token;
     } catch (error) {
-      if (error instanceof AuthServiceError) {
+      if (error instanceof UnauthorizedError) {
         throw error;
       }
-      throw new AuthServiceError('Authentication failed', 'AUTH_ERROR');
+      throw new Error(`Login failed: ${error}`);
     }
   }
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,121 @@
+import bcrypt from 'bcrypt';
+import { IUserRepository } from '../repositories/IUserRepository';
+import { IJWTHandler } from '../security/IJWTHandler';
+import { IPasswordHasher } from '../security/IPasswordHasher';
+
+interface RegisterRequest {
+  email: string;
+  password: string;
+}
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+interface RegisterResponse {
+  id: number;
+}
+
+interface LoginResponse {
+  token: string;
+}
+
+export class AuthServiceError extends Error {
+  public readonly code: string;
+  
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+/**
+ * Authentication service handling user registration and login business logic
+ */
+export class AuthService {
+  private readonly userRepository: IUserRepository;
+  private readonly passwordHasher: IPasswordHasher;
+  private readonly jwtHandler: IJWTHandler;
+
+  constructor(
+    userRepository: IUserRepository,
+    passwordHasher: IPasswordHasher,
+    jwtHandler: IJWTHandler
+  ) {
+    this.userRepository = userRepository;
+    this.passwordHasher = passwordHasher;
+    this.jwtHandler = jwtHandler;
+  }
+
+  /**
+   * Register a new user with email uniqueness validation
+   * @param request - Registration request containing email and password
+   * @returns Promise resolving to user ID
+   * @throws AuthServiceError for validation errors or duplicate email
+   */
+  async register(request: RegisterRequest): Promise<RegisterResponse> {
+    try {
+      // Check if email already exists
+      const existingUser = await this.userRepository.findByEmail(request.email);
+      if (existingUser) {
+        throw new AuthServiceError('Email already registered', 'DUPLICATE_EMAIL');
+      }
+
+      // Hash password before storage
+      const hashedPassword = await this.passwordHasher.hash(request.password);
+
+      // Create user
+      const user = await this.userRepository.create({
+        email: request.email,
+        password: hashedPassword
+      });
+
+      return { id: user.id };
+    } catch (error) {
+      if (error instanceof AuthServiceError) {
+        throw error;
+      }
+      throw new AuthServiceError('Registration failed', 'REGISTRATION_ERROR');
+    }
+  }
+
+  /**
+   * Authenticate user credentials and generate JWT token
+   * @param request - Login request containing email and password
+   * @returns Promise resolving to JWT token
+   * @throws AuthServiceError for invalid credentials
+   */
+  async login(request: LoginRequest): Promise<LoginResponse> {
+    try {
+      // Find user by email
+      const user = await this.userRepository.findByEmail(request.email);
+      if (!user) {
+        throw new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS');
+      }
+
+      // Verify password
+      const isValidPassword = await this.passwordHasher.verify(
+        request.password,
+        user.password
+      );
+      
+      if (!isValidPassword) {
+        throw new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS');
+      }
+
+      // Generate JWT token
+      const token = await this.jwtHandler.generateToken({
+        userId: user.id,
+        email: user.email
+      });
+
+      return { token };
+    } catch (error) {
+      if (error instanceof AuthServiceError) {
+        throw error;
+      }
+      throw new AuthServiceError('Authentication failed', 'AUTH_ERROR');
+    }
+  }
+}

--- a/src/services/__tests__/AuthService.test.ts
+++ b/src/services/__tests__/AuthService.test.ts
@@ -1,26 +1,23 @@
-import { AuthService, AuthServiceError } from '../AuthService';
-import { IUserRepository, User, CreateUserRequest } from '../../repositories/IUserRepository';
-import { IPasswordHasher } from '../../security/IPasswordHasher';
-import { IJWTHandler, JWTPayload } from '../../security/IJWTHandler';
+import { AuthService } from '../AuthService';
+import { IUserRepository } from '../../repositories/interfaces/IUserRepository';
+import { IPasswordHasher } from '../../security/interfaces/IPasswordHasher';
+import { IJwtHandler } from '../../security/interfaces/IJwtHandler';
+import { User } from '../../models/User';
+import { ConflictError, UnauthorizedError } from '../../errors/AppErrors';
 
 describe('AuthService', () => {
   let authService: AuthService;
   let mockUserRepository: jest.Mocked<IUserRepository>;
   let mockPasswordHasher: jest.Mocked<IPasswordHasher>;
-  let mockJWTHandler: jest.Mocked<IJWTHandler>;
-
-  const mockUser: User = {
-    id: 1,
-    email: 'test@example.com',
-    password: 'hashedpassword',
-    createdAt: new Date(),
-    updatedAt: new Date()
-  };
+  let mockJwtHandler: jest.Mocked<IJwtHandler>;
 
   beforeEach(() => {
     mockUserRepository = {
       findByEmail: jest.fn(),
-      create: jest.fn()
+      create: jest.fn(),
+      findById: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn()
     };
 
     mockPasswordHasher = {
@@ -28,7 +25,7 @@ describe('AuthService', () => {
       verify: jest.fn()
     };
 
-    mockJWTHandler = {
+    mockJwtHandler = {
       generateToken: jest.fn(),
       verifyToken: jest.fn()
     };
@@ -36,110 +33,116 @@ describe('AuthService', () => {
     authService = new AuthService(
       mockUserRepository,
       mockPasswordHasher,
-      mockJWTHandler
+      mockJwtHandler
     );
   });
 
   describe('register', () => {
-    it('should register new user successfully', async () => {
-      const request = { email: 'test@example.com', password: 'password123' };
-      
+    it('should register a new user successfully', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const hashedPassword = 'hashedPassword123';
+      const userId = 1;
+
       mockUserRepository.findByEmail.mockResolvedValue(null);
-      mockPasswordHasher.hash.mockResolvedValue('hashedpassword');
-      mockUserRepository.create.mockResolvedValue(mockUser);
+      mockPasswordHasher.hash.mockResolvedValue(hashedPassword);
+      mockUserRepository.create.mockResolvedValue(new User(email, hashedPassword, userId));
 
-      const result = await authService.register(request);
+      const result = await authService.register(email, password);
 
-      expect(result).toEqual({ id: 1 });
-      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(request.email);
-      expect(mockPasswordHasher.hash).toHaveBeenCalledWith(request.password);
-      expect(mockUserRepository.create).toHaveBeenCalledWith({
-        email: request.email,
-        password: 'hashedpassword'
-      });
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(email);
+      expect(mockPasswordHasher.hash).toHaveBeenCalledWith(password);
+      expect(mockUserRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ email, password: hashedPassword })
+      );
+      expect(result).toBe(userId);
     });
 
-    it('should throw error for duplicate email', async () => {
-      const request = { email: 'test@example.com', password: 'password123' };
+    it('should throw ConflictError when email already exists', async () => {
+      const email = 'existing@example.com';
+      const password = 'password123';
+      const existingUser = new User(email, 'hashedPassword', 1);
+
+      mockUserRepository.findByEmail.mockResolvedValue(existingUser);
+
+      await expect(authService.register(email, password))
+        .rejects.toThrow(ConflictError);
       
-      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
-
-      await expect(authService.register(request)).rejects.toThrow(
-        new AuthServiceError('Email already registered', 'DUPLICATE_EMAIL')
-      );
-
       expect(mockPasswordHasher.hash).not.toHaveBeenCalled();
       expect(mockUserRepository.create).not.toHaveBeenCalled();
     });
 
-    it('should throw generic error for repository failures', async () => {
-      const request = { email: 'test@example.com', password: 'password123' };
-      
-      mockUserRepository.findByEmail.mockRejectedValue(new Error('DB error'));
+    it('should throw error when repository fails', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const repositoryError = new Error('Database connection failed');
 
-      await expect(authService.register(request)).rejects.toThrow(
-        new AuthServiceError('Registration failed', 'REGISTRATION_ERROR')
-      );
+      mockUserRepository.findByEmail.mockRejectedValue(repositoryError);
+
+      await expect(authService.register(email, password))
+        .rejects.toThrow('Registration failed');
     });
   });
 
   describe('login', () => {
-    it('should authenticate user and return JWT token', async () => {
-      const request = { email: 'test@example.com', password: 'password123' };
-      const expectedToken = 'jwt.token.here';
-      
-      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+    it('should login successfully with valid credentials', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const hashedPassword = 'hashedPassword123';
+      const userId = 1;
+      const token = 'jwt.token.here';
+      const user = new User(email, hashedPassword, userId);
+
+      mockUserRepository.findByEmail.mockResolvedValue(user);
       mockPasswordHasher.verify.mockResolvedValue(true);
-      mockJWTHandler.generateToken.mockResolvedValue(expectedToken);
+      mockJwtHandler.generateToken.mockReturnValue(token);
 
-      const result = await authService.login(request);
+      const result = await authService.login(email, password);
 
-      expect(result).toEqual({ token: expectedToken });
-      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(request.email);
-      expect(mockPasswordHasher.verify).toHaveBeenCalledWith(
-        request.password,
-        mockUser.password
-      );
-      expect(mockJWTHandler.generateToken).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        email: mockUser.email
-      });
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(email);
+      expect(mockPasswordHasher.verify).toHaveBeenCalledWith(password, hashedPassword);
+      expect(mockJwtHandler.generateToken).toHaveBeenCalledWith({ userId, email });
+      expect(result).toBe(token);
     });
 
-    it('should throw error for non-existent user', async () => {
-      const request = { email: 'nonexistent@example.com', password: 'password123' };
-      
+    it('should throw UnauthorizedError when user not found', async () => {
+      const email = 'nonexistent@example.com';
+      const password = 'password123';
+
       mockUserRepository.findByEmail.mockResolvedValue(null);
 
-      await expect(authService.login(request)).rejects.toThrow(
-        new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS')
-      );
-
+      await expect(authService.login(email, password))
+        .rejects.toThrow(UnauthorizedError);
+      
       expect(mockPasswordHasher.verify).not.toHaveBeenCalled();
-      expect(mockJWTHandler.generateToken).not.toHaveBeenCalled();
+      expect(mockJwtHandler.generateToken).not.toHaveBeenCalled();
     });
 
-    it('should throw error for invalid password', async () => {
-      const request = { email: 'test@example.com', password: 'wrongpassword' };
-      
-      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+    it('should throw UnauthorizedError when password is invalid', async () => {
+      const email = 'test@example.com';
+      const password = 'wrongpassword';
+      const hashedPassword = 'hashedPassword123';
+      const userId = 1;
+      const user = new User(email, hashedPassword, userId);
+
+      mockUserRepository.findByEmail.mockResolvedValue(user);
       mockPasswordHasher.verify.mockResolvedValue(false);
 
-      await expect(authService.login(request)).rejects.toThrow(
-        new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS')
-      );
-
-      expect(mockJWTHandler.generateToken).not.toHaveBeenCalled();
+      await expect(authService.login(email, password))
+        .rejects.toThrow(UnauthorizedError);
+      
+      expect(mockJwtHandler.generateToken).not.toHaveBeenCalled();
     });
 
-    it('should throw generic error for service failures', async () => {
-      const request = { email: 'test@example.com', password: 'password123' };
-      
-      mockUserRepository.findByEmail.mockRejectedValue(new Error('DB error'));
+    it('should throw error when repository fails during login', async () => {
+      const email = 'test@example.com';
+      const password = 'password123';
+      const repositoryError = new Error('Database connection failed');
 
-      await expect(authService.login(request)).rejects.toThrow(
-        new AuthServiceError('Authentication failed', 'AUTH_ERROR')
-      );
+      mockUserRepository.findByEmail.mockRejectedValue(repositoryError);
+
+      await expect(authService.login(email, password))
+        .rejects.toThrow('Login failed');
     });
   });
 });

--- a/src/services/__tests__/AuthService.test.ts
+++ b/src/services/__tests__/AuthService.test.ts
@@ -1,0 +1,145 @@
+import { AuthService, AuthServiceError } from '../AuthService';
+import { IUserRepository, User, CreateUserRequest } from '../../repositories/IUserRepository';
+import { IPasswordHasher } from '../../security/IPasswordHasher';
+import { IJWTHandler, JWTPayload } from '../../security/IJWTHandler';
+
+describe('AuthService', () => {
+  let authService: AuthService;
+  let mockUserRepository: jest.Mocked<IUserRepository>;
+  let mockPasswordHasher: jest.Mocked<IPasswordHasher>;
+  let mockJWTHandler: jest.Mocked<IJWTHandler>;
+
+  const mockUser: User = {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashedpassword',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  beforeEach(() => {
+    mockUserRepository = {
+      findByEmail: jest.fn(),
+      create: jest.fn()
+    };
+
+    mockPasswordHasher = {
+      hash: jest.fn(),
+      verify: jest.fn()
+    };
+
+    mockJWTHandler = {
+      generateToken: jest.fn(),
+      verifyToken: jest.fn()
+    };
+
+    authService = new AuthService(
+      mockUserRepository,
+      mockPasswordHasher,
+      mockJWTHandler
+    );
+  });
+
+  describe('register', () => {
+    it('should register new user successfully', async () => {
+      const request = { email: 'test@example.com', password: 'password123' };
+      
+      mockUserRepository.findByEmail.mockResolvedValue(null);
+      mockPasswordHasher.hash.mockResolvedValue('hashedpassword');
+      mockUserRepository.create.mockResolvedValue(mockUser);
+
+      const result = await authService.register(request);
+
+      expect(result).toEqual({ id: 1 });
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(request.email);
+      expect(mockPasswordHasher.hash).toHaveBeenCalledWith(request.password);
+      expect(mockUserRepository.create).toHaveBeenCalledWith({
+        email: request.email,
+        password: 'hashedpassword'
+      });
+    });
+
+    it('should throw error for duplicate email', async () => {
+      const request = { email: 'test@example.com', password: 'password123' };
+      
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+
+      await expect(authService.register(request)).rejects.toThrow(
+        new AuthServiceError('Email already registered', 'DUPLICATE_EMAIL')
+      );
+
+      expect(mockPasswordHasher.hash).not.toHaveBeenCalled();
+      expect(mockUserRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should throw generic error for repository failures', async () => {
+      const request = { email: 'test@example.com', password: 'password123' };
+      
+      mockUserRepository.findByEmail.mockRejectedValue(new Error('DB error'));
+
+      await expect(authService.register(request)).rejects.toThrow(
+        new AuthServiceError('Registration failed', 'REGISTRATION_ERROR')
+      );
+    });
+  });
+
+  describe('login', () => {
+    it('should authenticate user and return JWT token', async () => {
+      const request = { email: 'test@example.com', password: 'password123' };
+      const expectedToken = 'jwt.token.here';
+      
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+      mockPasswordHasher.verify.mockResolvedValue(true);
+      mockJWTHandler.generateToken.mockResolvedValue(expectedToken);
+
+      const result = await authService.login(request);
+
+      expect(result).toEqual({ token: expectedToken });
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith(request.email);
+      expect(mockPasswordHasher.verify).toHaveBeenCalledWith(
+        request.password,
+        mockUser.password
+      );
+      expect(mockJWTHandler.generateToken).toHaveBeenCalledWith({
+        userId: mockUser.id,
+        email: mockUser.email
+      });
+    });
+
+    it('should throw error for non-existent user', async () => {
+      const request = { email: 'nonexistent@example.com', password: 'password123' };
+      
+      mockUserRepository.findByEmail.mockResolvedValue(null);
+
+      await expect(authService.login(request)).rejects.toThrow(
+        new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS')
+      );
+
+      expect(mockPasswordHasher.verify).not.toHaveBeenCalled();
+      expect(mockJWTHandler.generateToken).not.toHaveBeenCalled();
+    });
+
+    it('should throw error for invalid password', async () => {
+      const request = { email: 'test@example.com', password: 'wrongpassword' };
+      
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+      mockPasswordHasher.verify.mockResolvedValue(false);
+
+      await expect(authService.login(request)).rejects.toThrow(
+        new AuthServiceError('Invalid credentials', 'INVALID_CREDENTIALS')
+      );
+
+      expect(mockJWTHandler.generateToken).not.toHaveBeenCalled();
+    });
+
+    it('should throw generic error for service failures', async () => {
+      const request = { email: 'test@example.com', password: 'password123' };
+      
+      mockUserRepository.findByEmail.mockRejectedValue(new Error('DB error'));
+
+      await expect(authService.login(request)).rejects.toThrow(
+        new AuthServiceError('Authentication failed', 'AUTH_ERROR')
+      );
+    });
+  });
+});

--- a/src/services/__tests__/auth.service.test.ts
+++ b/src/services/__tests__/auth.service.test.ts
@@ -1,0 +1,125 @@
+import { AuthService } from '../auth.service.js';
+import { UserRepository } from '../../repositories/user.repository.js';
+import { PasswordHasher } from '../../security/password-hasher.js';
+import { JWTHandler } from '../../security/jwt-handler.js';
+import { User } from '../../types/user.js';
+
+const mockUser: User = {
+  id: 1,
+  email: 'test@example.com',
+  password: 'hashedPassword123'
+};
+
+const mockUserRepository = {
+  findByEmail: jest.fn(),
+  create: jest.fn()
+} as unknown as UserRepository;
+
+const mockPasswordHasher = {
+  hash: jest.fn(),
+  verify: jest.fn()
+} as unknown as PasswordHasher;
+
+const mockJwtHandler = {
+  generateToken: jest.fn()
+} as unknown as JWTHandler;
+
+describe('AuthService', () => {
+  let authService: AuthService;
+
+  beforeEach(() => {
+    authService = new AuthService(mockUserRepository, mockPasswordHasher, mockJwtHandler);
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('should register a new user successfully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockResolvedValue(null);
+      (mockPasswordHasher.hash as jest.Mock).mockResolvedValue('hashedPassword123');
+      (mockUserRepository.create as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await authService.register('test@example.com', 'password123');
+
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(mockPasswordHasher.hash).toHaveBeenCalledWith('password123');
+      expect(mockUserRepository.create).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'hashedPassword123'
+      });
+      expect(result).toBe(1);
+    });
+
+    it('should throw error when user already exists', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+
+      await expect(authService.register('test@example.com', 'password123'))
+        .rejects.toThrow('User with this email already exists');
+
+      expect(mockPasswordHasher.hash).not.toHaveBeenCalled();
+      expect(mockUserRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should handle repository errors gracefully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockRejectedValue(new Error('Database connection failed'));
+
+      await expect(authService.register('test@example.com', 'password123'))
+        .rejects.toThrow('Registration failed: Database connection failed');
+    });
+
+    it('should handle unknown errors gracefully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockRejectedValue('Unknown error');
+
+      await expect(authService.register('test@example.com', 'password123'))
+        .rejects.toThrow('Registration failed due to unknown error');
+    });
+  });
+
+  describe('login', () => {
+    it('should login user successfully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      (mockPasswordHasher.verify as jest.Mock).mockResolvedValue(true);
+      (mockJwtHandler.generateToken as jest.Mock).mockReturnValue('jwt.token.here');
+
+      const result = await authService.login('test@example.com', 'password123');
+
+      expect(mockUserRepository.findByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(mockPasswordHasher.verify).toHaveBeenCalledWith('password123', 'hashedPassword123');
+      expect(mockJwtHandler.generateToken).toHaveBeenCalledWith({ userId: 1 });
+      expect(result).toBe('jwt.token.here');
+    });
+
+    it('should throw error for non-existent user', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockResolvedValue(null);
+
+      await expect(authService.login('test@example.com', 'password123'))
+        .rejects.toThrow('Invalid credentials');
+
+      expect(mockPasswordHasher.verify).not.toHaveBeenCalled();
+      expect(mockJwtHandler.generateToken).not.toHaveBeenCalled();
+    });
+
+    it('should throw error for invalid password', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      (mockPasswordHasher.verify as jest.Mock).mockResolvedValue(false);
+
+      await expect(authService.login('test@example.com', 'wrongpassword'))
+        .rejects.toThrow('Invalid credentials');
+
+      expect(mockJwtHandler.generateToken).not.toHaveBeenCalled();
+    });
+
+    it('should handle repository errors gracefully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockRejectedValue(new Error('Database timeout'));
+
+      await expect(authService.login('test@example.com', 'password123'))
+        .rejects.toThrow('Login failed: Database timeout');
+    });
+
+    it('should handle unknown errors gracefully', async () => {
+      (mockUserRepository.findByEmail as jest.Mock).mockRejectedValue('Network error');
+
+      await expect(authService.login('test@example.com', 'password123'))
+        .rejects.toThrow('Login failed due to unknown error');
+    });
+  });
+});

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,92 @@
+import { UserRepository } from '../repositories/user.repository.js';
+import { PasswordHasher } from '../security/password-hasher.js';
+import { JWTHandler } from '../security/jwt-handler.js';
+import { User } from '../types/user.js';
+
+/**
+ * Service for handling user authentication operations including registration and login
+ */
+export class AuthService {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly passwordHasher: PasswordHasher,
+    private readonly jwtHandler: JWTHandler
+  ) {}
+
+  /**
+   * Registers a new user with email uniqueness validation and password hashing
+   * @param email - User's email address
+   * @param password - User's plain text password
+   * @returns Promise resolving to the created user's ID
+   * @throws Error if email already exists or registration fails
+   */
+  async register(email: string, password: string): Promise<number> {
+    try {
+      const existingUser = await this.userRepository.findByEmail(email);
+      if (existingUser) {
+        throw new Error('User with this email already exists');
+      }
+
+      return await this.createUser(email, password);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'User with this email already exists') {
+          throw error;
+        }
+        throw new Error('Registration failed: ' + error.message);
+      }
+      throw new Error('Registration failed due to unknown error');
+    }
+  }
+
+  /**
+   * Authenticates user credentials and generates JWT token
+   * @param email - User's email address
+   * @param password - User's plain text password
+   * @returns Promise resolving to JWT token
+   * @throws Error if credentials are invalid or login fails
+   */
+  async login(email: string, password: string): Promise<string> {
+    try {
+      const user = await this.userRepository.findByEmail(email);
+      if (!user) {
+        throw new Error('Invalid credentials');
+      }
+
+      return await this.authenticateUser(user, password);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Invalid credentials') {
+          throw error;
+        }
+        throw new Error('Login failed: ' + error.message);
+      }
+      throw new Error('Login failed due to unknown error');
+    }
+  }
+
+  /**
+   * Creates a new user with hashed password
+   * @private
+   */
+  private async createUser(email: string, password: string): Promise<number> {
+    const hashedPassword = await this.passwordHasher.hash(password);
+    const user = await this.userRepository.create({
+      email,
+      password: hashedPassword
+    });
+    return user.id;
+  }
+
+  /**
+   * Authenticates user and generates JWT token
+   * @private
+   */
+  private async authenticateUser(user: User, password: string): Promise<string> {
+    const isValidPassword = await this.passwordHasher.verify(password, user.password);
+    if (!isValidPassword) {
+      throw new Error('Invalid credentials');
+    }
+    return this.jwtHandler.generateToken({ userId: user.id });
+  }
+}


### PR DESCRIPTION
## Summary
Refactors the AuthService by extracting private methods from register() and login() to reduce line count and improves error handling to preserve original error context using error.message property instead of generic string interpolation.

## Linked Issue
Closes #170

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-001 | ✅ | Register method validates email uniqueness before creating user |
| AC-002 | ✅ | Password is hashed using PasswordHasher before storage in createUser method |
| AC-003 | ✅ | Login method authenticates credentials via password verification |
| AC-004 | ✅ | JWT token is generated on successful authentication |
| AC-005 | ✅ | Invalid credentials errors are thrown for non-existent users and wrong passwords |

## Notes for Reviewer
Fixed all three issues: extracted createUser() and authenticateUser() private methods to keep register() and login() under 30 lines, improved error handling to preserve original error context using error.message instead of generic interpolation
## Revision 2 — TL review changes incorporated
