### PR TITLE
feat: Task 22 - Todo Controller Tests

### DIFF
--- a/src/controllers/__tests__/todo.controller.test.ts
+++ b/src/controllers/__tests__/todo.controller.test.ts
@@ -1,0 +1,449 @@
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { todoController } from '../todo.controller';
+import { todoService } from '../../services/todo.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+
+// Mock dependencies
+jest.mock('../../services/todo.service');
+jest.mock('jsonwebtoken');
+
+const mockTodoService = todoService as jest.Mocked<typeof todoService>;
+const mockJwt = jwt as jest.Mocked<typeof jwt>;
+
+// Test constants
+const VALID_JWT_SECRET = 'test-jwt-secret';
+const MOCK_USER_ID = 1;
+const VALID_TOKEN = 'valid.jwt.token';
+const INVALID_TOKEN = 'invalid.token';
+const MALFORMED_JSON = '{ "title": invalid json }';
+const MAX_TITLE_LENGTH = 1000;
+const LARGE_TITLE = 'a'.repeat(MAX_TITLE_LENGTH + 1);
+
+// Sample todo data
+const mockTodo = {
+  id: 1,
+  title: 'Test Todo',
+  completed: false,
+  userId: MOCK_USER_ID,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+
+const mockTodos = [mockTodo];
+
+describe('Todo Controller Integration Tests', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    // Setup express app with middleware
+    app = express();
+    app.use(express.json({ limit: '1mb' }));
+    
+    // Mock JWT verification
+    mockJwt.verify.mockImplementation((token: string, secret: string) => {
+      if (token === VALID_TOKEN && secret === VALID_JWT_SECRET) {
+        return { userId: MOCK_USER_ID };
+      }
+      throw new Error('Invalid token');
+    });
+
+    // Setup routes with auth middleware
+    app.get('/todos', authMiddleware, todoController.getTodos);
+    app.post('/todos', authMiddleware, todoController.createTodo);
+    app.put('/todos/:id', authMiddleware, todoController.updateTodo);
+    app.delete('/todos/:id', authMiddleware, todoController.deleteTodo);
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  describe('GET /todos', () => {
+    it('should return 200 with user todos when authenticated', async () => {
+      mockTodoService.getTodosByUserId.mockResolvedValue(mockTodos);
+
+      const response = await request(app)
+        .get('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockTodos);
+      expect(mockTodoService.getTodosByUserId).toHaveBeenCalledWith(MOCK_USER_ID);
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .get('/todos');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.getTodosByUserId).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is invalid', async () => {
+      const response = await request(app)
+        .get('/todos')
+        .set('Authorization', `Bearer ${INVALID_TOKEN}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.getTodosByUserId).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when service layer fails', async () => {
+      mockTodoService.getTodosByUserId.mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await request(app)
+        .get('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('error');
+    });
+  });
+
+  describe('POST /todos', () => {
+    const validTodoData = { title: 'New Todo', completed: false };
+
+    it('should return 201 with created todo when valid data provided', async () => {
+      mockTodoService.createTodo.mockResolvedValue(mockTodo);
+
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send(validTodoData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual(mockTodo);
+      expect(mockTodoService.createTodo).toHaveBeenCalledWith({
+        ...validTodoData,
+        userId: MOCK_USER_ID
+      });
+    });
+
+    it('should return 400 when title is missing', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ completed: false });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when title is empty string', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: '', completed: false });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when title is not a string', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 123, completed: false });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when completed is not a boolean', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Test Todo', completed: 'true' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when title exceeds maximum length', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: LARGE_TITLE, completed: false });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for malformed JSON payload', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .set('Content-Type', 'application/json')
+        .send(MALFORMED_JSON);
+
+      expect(response.status).toBe(400);
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .send(validTodoData);
+
+      expect(response.status).toBe(401);
+      expect(mockTodoService.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when service layer fails', async () => {
+      mockTodoService.createTodo.mockRejectedValue(new Error('Database insert failed'));
+
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send(validTodoData);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('error');
+    });
+  });
+
+  describe('PUT /todos/:id', () => {
+    const todoId = '1';
+    const updatedTodo = { ...mockTodo, title: 'Updated Todo', completed: true };
+
+    it('should return 200 with updated todo when valid full update', async () => {
+      mockTodoService.updateTodo.mockResolvedValue(updatedTodo);
+
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Updated Todo', completed: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(updatedTodo);
+      expect(mockTodoService.updateTodo).toHaveBeenCalledWith(
+        parseInt(todoId),
+        MOCK_USER_ID,
+        { title: 'Updated Todo', completed: true }
+      );
+    });
+
+    it('should return 200 with partial update (title only)', async () => {
+      const partialUpdate = { ...mockTodo, title: 'Partially Updated' };
+      mockTodoService.updateTodo.mockResolvedValue(partialUpdate);
+
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Partially Updated' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(partialUpdate);
+      expect(mockTodoService.updateTodo).toHaveBeenCalledWith(
+        parseInt(todoId),
+        MOCK_USER_ID,
+        { title: 'Partially Updated' }
+      );
+    });
+
+    it('should return 200 with partial update (completed only)', async () => {
+      const partialUpdate = { ...mockTodo, completed: true };
+      mockTodoService.updateTodo.mockResolvedValue(partialUpdate);
+
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ completed: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(partialUpdate);
+      expect(mockTodoService.updateTodo).toHaveBeenCalledWith(
+        parseInt(todoId),
+        MOCK_USER_ID,
+        { completed: true }
+      );
+    });
+
+    it('should return 400 when title is empty string', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: '' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when title is not a string', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 123 });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when completed is not a boolean', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ completed: 'false' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when title exceeds maximum length', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: LARGE_TITLE });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for malformed JSON payload', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .set('Content-Type', 'application/json')
+        .send(MALFORMED_JSON);
+
+      expect(response.status).toBe(400);
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when todo ID is not numeric', async () => {
+      const response = await request(app)
+        .put('/todos/invalid-id')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Updated Todo' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when todo ID is negative', async () => {
+      const response = await request(app)
+        .put('/todos/-1')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Updated Todo' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when todo does not exist', async () => {
+      mockTodoService.updateTodo.mockResolvedValue(null);
+
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Updated Todo' });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty('error');
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .send({ title: 'Updated Todo' });
+
+      expect(response.status).toBe(401);
+      expect(mockTodoService.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when service layer fails', async () => {
+      mockTodoService.updateTodo.mockRejectedValue(new Error('Database update failed'));
+
+      const response = await request(app)
+        .put(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`)
+        .send({ title: 'Updated Todo' });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('error');
+    });
+  });
+
+  describe('DELETE /todos/:id', () => {
+    const todoId = '1';
+
+    it('should return 204 when todo is successfully deleted', async () => {
+      mockTodoService.deleteTodo.mockResolvedValue(true);
+
+      const response = await request(app)
+        .delete(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(204);
+      expect(response.body).toEqual({});
+      expect(mockTodoService.deleteTodo).toHaveBeenCalledWith(
+        parseInt(todoId),
+        MOCK_USER_ID
+      );
+    });
+
+    it('should return 400 when todo ID is not numeric', async () => {
+      const response = await request(app)
+        .delete('/todos/invalid-id')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.deleteTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when todo ID is negative', async () => {
+      const response = await request(app)
+        .delete('/todos/-1')
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+      expect(mockTodoService.deleteTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when todo does not exist', async () => {
+      mockTodoService.deleteTodo.mockResolvedValue(false);
+
+      const response = await request(app)
+        .delete(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty('error');
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .delete(`/todos/${todoId}`);
+
+      expect(response.status).toBe(401);
+      expect(mockTodoService.deleteTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when service layer fails', async () => {
+      mockTodoService.deleteTodo.mockRejectedValue(new Error('Database delete failed'));
+
+      const response = await request(app)
+        .delete(`/todos/${todoId}`)
+        .set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('error');
+    });
+  });
+});

--- a/src/controllers/__tests__/todoController.integration.test.ts
+++ b/src/controllers/__tests__/todoController.integration.test.ts
@@ -1,0 +1,239 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../app';
+import { TodoService } from '../../services/TodoService';
+
+// Mock the TodoService
+jest.mock('../../services/TodoService');
+const mockTodoService = TodoService as jest.MockedClass<typeof TodoService>;
+
+const JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+const VALID_USER_ID = 1;
+const MOCK_TODO_ID = 123;
+
+const MOCK_TODO = {
+  id: MOCK_TODO_ID,
+  title: 'Test Todo',
+  description: 'Test Description',
+  completed: false,
+  userId: VALID_USER_ID,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+};
+
+const MOCK_UPDATED_TODO = {
+  ...MOCK_TODO,
+  title: 'Updated Todo',
+  completed: true
+};
+
+/**
+ * Generates a valid JWT token for testing
+ * @param userId - The user ID to encode in the token
+ * @returns JWT token string
+ */
+function generateValidToken(userId: number): string {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+describe('Todo Controller Integration Tests', () => {
+  let validToken: string;
+  let mockTodoServiceInstance: jest.Mocked<TodoService>;
+
+  beforeAll(() => {
+    validToken = generateValidToken(VALID_USER_ID);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTodoServiceInstance = {
+      getTodosByUserId: jest.fn(),
+      createTodo: jest.fn(),
+      updateTodo: jest.fn(),
+      deleteTodo: jest.fn(),
+      getTodoById: jest.fn()
+    } as any;
+    mockTodoService.mockImplementation(() => mockTodoServiceInstance);
+  });
+
+  describe('GET /todos', () => {
+    it('should return 200 with user\'s todos when authenticated', async () => {
+      const mockTodos = [MOCK_TODO, { ...MOCK_TODO, id: 124, title: 'Another Todo' }];
+      mockTodoServiceInstance.getTodosByUserId.mockResolvedValue(mockTodos);
+
+      const response = await request(app)
+        .get('/todos')
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockTodos);
+      expect(mockTodoServiceInstance.getTodosByUserId).toHaveBeenCalledWith(VALID_USER_ID);
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .get('/todos');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Access denied. No token provided.');
+      expect(mockTodoServiceInstance.getTodosByUserId).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is invalid', async () => {
+      const response = await request(app)
+        .get('/todos')
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Invalid token.');
+      expect(mockTodoServiceInstance.getTodosByUserId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /todos', () => {
+    const newTodoData = {
+      title: 'New Todo',
+      description: 'New Description'
+    };
+
+    it('should return 201 with created todo when authenticated', async () => {
+      mockTodoServiceInstance.createTodo.mockResolvedValue(MOCK_TODO);
+
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(newTodoData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual(MOCK_TODO);
+      expect(mockTodoServiceInstance.createTodo).toHaveBeenCalledWith({
+        ...newTodoData,
+        userId: VALID_USER_ID
+      });
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .send(newTodoData);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Access denied. No token provided.');
+      expect(mockTodoServiceInstance.createTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is invalid', async () => {
+      const response = await request(app)
+        .post('/todos')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(newTodoData);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Invalid token.');
+      expect(mockTodoServiceInstance.createTodo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT /todos/:id', () => {
+    const updateData = {
+      title: 'Updated Todo',
+      completed: true
+    };
+
+    it('should return 200 with updated todo when authenticated and todo exists', async () => {
+      mockTodoServiceInstance.getTodoById.mockResolvedValue(MOCK_TODO);
+      mockTodoServiceInstance.updateTodo.mockResolvedValue(MOCK_UPDATED_TODO);
+
+      const response = await request(app)
+        .put(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(updateData);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(MOCK_UPDATED_TODO);
+      expect(mockTodoServiceInstance.getTodoById).toHaveBeenCalledWith(MOCK_TODO_ID, VALID_USER_ID);
+      expect(mockTodoServiceInstance.updateTodo).toHaveBeenCalledWith(MOCK_TODO_ID, updateData);
+    });
+
+    it('should return 404 when todo does not exist or belongs to another user', async () => {
+      mockTodoServiceInstance.getTodoById.mockResolvedValue(null);
+
+      const response = await request(app)
+        .put(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', `Bearer ${validToken}`)
+        .send(updateData);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe('Todo not found');
+      expect(mockTodoServiceInstance.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .put(`/todos/${MOCK_TODO_ID}`)
+        .send(updateData);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Access denied. No token provided.');
+      expect(mockTodoServiceInstance.updateTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is invalid', async () => {
+      const response = await request(app)
+        .put(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', 'Bearer invalid-token')
+        .send(updateData);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Invalid token.');
+      expect(mockTodoServiceInstance.updateTodo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /todos/:id', () => {
+    it('should return 204 on successful deletion when authenticated and todo exists', async () => {
+      mockTodoServiceInstance.getTodoById.mockResolvedValue(MOCK_TODO);
+      mockTodoServiceInstance.deleteTodo.mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .delete(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(204);
+      expect(response.body).toEqual({});
+      expect(mockTodoServiceInstance.getTodoById).toHaveBeenCalledWith(MOCK_TODO_ID, VALID_USER_ID);
+      expect(mockTodoServiceInstance.deleteTodo).toHaveBeenCalledWith(MOCK_TODO_ID);
+    });
+
+    it('should return 404 when todo does not exist or belongs to another user', async () => {
+      mockTodoServiceInstance.getTodoById.mockResolvedValue(null);
+
+      const response = await request(app)
+        .delete(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', `Bearer ${validToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe('Todo not found');
+      expect(mockTodoServiceInstance.deleteTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is missing', async () => {
+      const response = await request(app)
+        .delete(`/todos/${MOCK_TODO_ID}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Access denied. No token provided.');
+      expect(mockTodoServiceInstance.deleteTodo).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT token is invalid', async () => {
+      const response = await request(app)
+        .delete(`/todos/${MOCK_TODO_ID}`)
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Invalid token.');
+      expect(mockTodoServiceInstance.deleteTodo).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Comprehensive integration tests for todo CRUD API endpoints with JWT authentication, covering all success and error scenarios. Tests include input validation, error handling, partial updates, and edge cases for malformed requests and service failures.

## Linked Issue
Closes #183

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-001 | ✅ | Tests GET /todos returns 200 with user's todos and handles service failures with 500 responses |
| AC-002 | ✅ | Tests POST /todos returns 201 with created todo, validates required fields, data types, and oversized inputs |
| AC-003 | ✅ | Tests PUT /todos/:id returns 200 with updated todo, verifies partial updates work correctly, validates input data |
| AC-004 | ✅ | Tests DELETE /todos/:id returns 204 on success and handles non-existent todos with 404 |
| AC-005 | ✅ | Tests 401 responses for missing JWT tokens across all endpoints |
| AC-006 | ✅ | Tests 404 responses for non-existent todos in PUT and DELETE operations |

## Notes for Reviewer
All revision issues addressed: Added comprehensive input validation tests for POST/PUT (empty/missing fields, invalid types, oversized data), error handling tests for service failures (500 responses), partial update verification for PUT, invalid URL parameter format tests, and 400 Bad Request tests for malformed JSON. Tests use supertest with mocked JWT tokens and todo service as specified.
## Revision 1 — TL review changes incorporated
