### PR TITLE
feat: Task 9 - Implement create todo endpoint

### DIFF
--- a/src/controllers/todoController.ts
+++ b/src/controllers/todoController.ts
@@ -1,0 +1,41 @@
+import { Request, Response } from 'express';
+import { todoService } from '../services/todoService';
+import { AuthenticatedRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+const HTTP_STATUS_CREATED = 201;
+const HTTP_STATUS_BAD_REQUEST = 400;
+const HTTP_STATUS_INTERNAL_ERROR = 500;
+
+/**
+ * Controller for creating a new todo item
+ * Handles POST /api/todos endpoint
+ * @param req - Express request object with authenticated user
+ * @param res - Express response object
+ */
+export const createTodoController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const userId = authReq.user.id;
+    const { title, description, due_date } = req.body;
+
+    logger.info('Creating todo item', { userId, title });
+
+    const newTodo = await todoService.createTodo({
+      userId,
+      title,
+      description,
+      due_date
+    });
+
+    res.status(HTTP_STATUS_CREATED).json(newTodo);
+  } catch (error) {
+    logger.error('Error creating todo item', { error: error.message, userId: (req as AuthenticatedRequest).user?.id });
+    res.status(HTTP_STATUS_INTERNAL_ERROR).json({
+      error: 'Internal server error'
+    });
+  }
+};

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../utils/logger';
+
+const HTTP_STATUS_BAD_REQUEST = 400;
+const MIN_TITLE_LENGTH = 1;
+
+/**
+ * Validation middleware for todo creation requests
+ * Validates required fields and data types
+ * @param req - Express request object
+ * @param res - Express response object  
+ * @param next - Express next function
+ */
+export const validateCreateTodo = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const { title, description, due_date } = req.body;
+
+  // Validate title is required and not empty
+  if (!title || typeof title !== 'string' || title.trim().length < MIN_TITLE_LENGTH) {
+    logger.warn('Todo creation validation failed: invalid title', { title });
+    res.status(HTTP_STATUS_BAD_REQUEST).json({
+      error: 'Title is required and cannot be empty'
+    });
+    return;
+  }
+
+  // Validate optional description if provided
+  if (description !== undefined && typeof description !== 'string') {
+    logger.warn('Todo creation validation failed: invalid description type');
+    res.status(HTTP_STATUS_BAD_REQUEST).json({
+      error: 'Description must be a string'
+    });
+    return;
+  }
+
+  // Validate optional due_date if provided
+  if (due_date !== undefined) {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (typeof due_date !== 'string' || !dateRegex.test(due_date)) {
+      logger.warn('Todo creation validation failed: invalid due_date format');
+      res.status(HTTP_STATUS_BAD_REQUEST).json({
+        error: 'Due date must be in YYYY-MM-DD format'
+      });
+      return;
+    }
+  }
+
+  next();
+};

--- a/src/repositories/todoRepository.ts
+++ b/src/repositories/todoRepository.ts
@@ -1,0 +1,66 @@
+import { Pool } from 'pg';
+import { dbPool } from '../config/database';
+import { Todo } from '../types/todo';
+import { logger } from '../utils/logger';
+import { v4 as uuidv4 } from 'uuid';
+
+interface CreateTodoData {
+  userId: string;
+  title: string;
+  description?: string;
+  due_date?: string;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Repository for todo data access operations
+ * Handles database interactions for todo entities
+ */
+class TodoRepository {
+  private pool: Pool;
+
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
+
+  /**
+   * Creates a new todo item in the database
+   * @param todoData - Complete todo data including all fields
+   * @returns Promise resolving to created todo with generated ID
+   */
+  async create(todoData: CreateTodoData): Promise<Todo> {
+    const client = await this.pool.connect();
+    
+    try {
+      const id = uuidv4();
+      const query = `
+        INSERT INTO todos (id, user_id, title, description, due_date, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        RETURNING *
+      `;
+      
+      const values = [
+        id,
+        todoData.userId,
+        todoData.title,
+        todoData.description || null,
+        todoData.due_date || null,
+        todoData.status,
+        todoData.created_at,
+        todoData.updated_at
+      ];
+
+      const result = await client.query(query, values);
+      return result.rows[0] as Todo;
+    } catch (error) {
+      logger.error('Database error creating todo', { error: error.message, userId: todoData.userId });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+export const todoRepository = new TodoRepository(dbPool);

--- a/src/routes/todos.ts
+++ b/src/routes/todos.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { authenticateToken } from '../middleware/auth';
+import { createTodoController } from '../controllers/todoController';
+import { validateCreateTodo } from '../middleware/validation';
+
+const router = express.Router();
+
+/**
+ * POST /api/todos endpoint for creating new todo items
+ * Requires authentication and validates input data
+ */
+router.post('/', authenticateToken, validateCreateTodo, createTodoController);
+
+export default router;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,0 +1,37 @@
+import { todoRepository } from '../repositories/todoRepository';
+import { Todo, CreateTodoData } from '../types/todo';
+import { logger } from '../utils/logger';
+
+const DEFAULT_TODO_STATUS = 'open';
+
+/**
+ * Service layer for todo operations
+ * Handles business logic and data validation
+ */
+class TodoService {
+  /**
+   * Creates a new todo item for a user
+   * @param todoData - Todo creation data including userId, title, optional description and due_date
+   * @returns Promise resolving to created todo with generated ID
+   */
+  async createTodo(todoData: CreateTodoData): Promise<Todo> {
+    try {
+      const todoToCreate = {
+        ...todoData,
+        status: DEFAULT_TODO_STATUS,
+        created_at: new Date(),
+        updated_at: new Date()
+      };
+
+      logger.info('Creating todo in service layer', { userId: todoData.userId, title: todoData.title });
+
+      const createdTodo = await todoRepository.create(todoToCreate);
+      return createdTodo;
+    } catch (error) {
+      logger.error('Error in todo service createTodo', { error: error.message, userId: todoData.userId });
+      throw new Error(`Failed to create todo: ${error.message}`);
+    }
+  }
+}
+
+export const todoService = new TodoService();

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+
+/**
+ * User information extracted from JWT token
+ */
+export interface JWTUser {
+  id: string;
+  email: string;
+}
+
+/**
+ * Extended Express Request interface with authenticated user information
+ * Used by authentication middleware to attach user data to requests
+ */
+export interface AuthenticatedRequest extends Request {
+  user: JWTUser;
+}

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,34 @@
+/**
+ * Todo entity interface representing a todo item in the system
+ */
+export interface Todo {
+  id: string;
+  user_id: string;
+  title: string;
+  description?: string;
+  due_date?: string;
+  status: 'open' | 'completed';
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Data required to create a new todo item
+ * Excludes system-generated fields like id, timestamps
+ */
+export interface CreateTodoData {
+  userId: string;
+  title: string;
+  description?: string;
+  due_date?: string;
+}
+
+/**
+ * Todo status enumeration for type safety
+ */
+export const TODO_STATUS = {
+  OPEN: 'open' as const,
+  COMPLETED: 'completed' as const
+} as const;
+
+export type TodoStatus = typeof TODO_STATUS[keyof typeof TODO_STATUS];


### PR DESCRIPTION
## Summary
Implements POST /api/todos endpoint for creating new todo items with authentication, validation, and proper error handling. Uses service and repository pattern with PostgreSQL for data persistence.

## Linked Issue
Closes #345

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-012 | ✅ | Endpoint creates todo items for authenticated users via authenticateToken middleware |
| AC-013 | ✅ | Accepts title (required), description, and due_date fields with validation middleware |
| AC-014 | ✅ | New items default to 'open' status in todoService.createTodo() |
| AC-015 | ✅ | Returns 201 status with created item including UUID-generated ID |
| AC-016 | ✅ | validateCreateTodo middleware returns 400 if title is missing or empty |
| AC-017 | ✅ | authenticateToken middleware enforces authentication, returns 401 if not authenticated |

## Notes for Reviewer
Assumes authenticateToken middleware, dbPool, and logger utilities exist. Repository uses UUID for ID generation and expects todos table with specified schema.

