### PR TITLE
feat: Task 12 - Implement delete todo endpoint

### DIFF
--- a/src/controllers/todoController.ts
+++ b/src/controllers/todoController.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from 'express';
+import { todoService } from '../services/todoService';
+import { logger } from '../utils/logger';
+import { AuthenticatedRequest } from '../types/auth';
+
+class TodoController {
+  /**
+   * Deletes a todo item by ID for the authenticated user
+   * @param req - Express request object with authenticated user
+   * @param res - Express response object
+   */
+  async deleteTodo(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      const todoId = req.params.id;
+      const userId = req.user.id;
+
+      if (!todoId) {
+        res.status(400).json({ error: 'Todo ID is required' });
+        return;
+      }
+
+      const deleted = await todoService.deleteTodo(todoId, userId);
+      
+      if (!deleted) {
+        res.status(404).json({ error: 'Todo not found' });
+        return;
+      }
+
+      res.status(204).send();
+    } catch (error) {
+      logger.error('Error deleting todo:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+}
+
+export const todoController = new TodoController();

--- a/src/routes/todos.ts
+++ b/src/routes/todos.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { authenticateToken } from '../middleware/auth';
+import { todoController } from '../controllers/todoController';
+
+const router = express.Router();
+
+// Apply authentication middleware to all todo routes
+router.use(authenticateToken);
+
+// DELETE /api/todos/:id - Delete a specific todo item
+router.delete('/:id', todoController.deleteTodo);
+
+export { router as todoRouter };

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,0 +1,37 @@
+import { pool } from '../config/database';
+import { logger } from '../utils/logger';
+
+class TodoService {
+  /**
+   * Permanently deletes a todo item from the database
+   * @param todoId - The ID of the todo item to delete
+   * @param userId - The ID of the authenticated user
+   * @returns Promise<boolean> - True if item was deleted, false if not found or no permission
+   */
+  async deleteTodo(todoId: string, userId: string): Promise<boolean> {
+    try {
+      const query = `
+        DELETE FROM todos 
+        WHERE id = $1 AND user_id = $2
+        RETURNING id
+      `;
+      
+      const result = await pool.query(query, [todoId, userId]);
+      
+      const wasDeleted = result.rowCount > 0;
+      
+      if (wasDeleted) {
+        logger.info(`Todo ${todoId} deleted by user ${userId}`);
+      } else {
+        logger.warn(`Failed to delete todo ${todoId} - not found or no permission for user ${userId}`);
+      }
+      
+      return wasDeleted;
+    } catch (error) {
+      logger.error('Error in deleteTodo service:', error);
+      throw error;
+    }
+  }
+}
+
+export const todoService = new TodoService();

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,16 @@
+import { Request } from 'express';
+
+/**
+ * Interface for authenticated user data
+ */
+export interface User {
+  id: string;
+  email: string;
+}
+
+/**
+ * Extended Express Request interface with authenticated user
+ */
+export interface AuthenticatedRequest extends Request {
+  user: User;
+}


### PR DESCRIPTION
## Summary
Implements DELETE /api/todos/:id endpoint that permanently removes todo items from the database. The endpoint validates user ownership and returns appropriate HTTP status codes based on the operation result.

## Linked Issue
Closes #348

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-029 | ✅ | DELETE route implemented with todoId parameter extraction and service call |
| AC-030 | ✅ | Returns 204 No Content status on successful deletion in controller |
| AC-031 | ✅ | Database query includes user_id filter to ensure ownership, returns 404 if not found |
| AC-032 | ✅ | Uses DELETE SQL statement for permanent removal from database |

## Notes for Reviewer
Implementation uses hard delete as specified in AC-032. The service layer validates user ownership through the WHERE clause combining todo ID and user ID, ensuring users cannot delete other users' todos. Error handling includes proper logging and HTTP status codes.

