### PR TITLE
feat: Task 17 - Implement todo creation endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const todoRoutes = require('./routes/todoRoutes');
+const errorHandler = require('./middleware/errorHandler');
+const logger = require('./utils/logger');
+
+const app = express();
+
+// Security middleware
+app.use(helmet());
+app.use(cors());
+
+// Rate limiting
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: {
+    success: false,
+    error: {
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many requests, please try again later'
+    }
+  }
+});
+app.use('/api/', limiter);
+
+// Body parsing middleware
+app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: true, limit: '1mb' }));
+
+// Request logging
+app.use((req, res, next) => {
+  logger.info(`${req.method} ${req.path} - ${req.ip}`);
+  next();
+});
+
+// Routes
+app.use('/api/todos', todoRoutes);
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+// Error handling middleware (must be last)
+app.use(errorHandler);
+
+module.exports = app;

--- a/src/controllers/todoController.js
+++ b/src/controllers/todoController.js
@@ -1,0 +1,50 @@
+const todoService = require('../services/todoService');
+const { validationResult } = require('express-validator');
+const logger = require('../utils/logger');
+
+/**
+ * Handles todo creation requests
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Function} next - Express next middleware function
+ */
+const createTodo = async (req, res, next) => {
+  try {
+    // Check for validation errors
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Missing required title field',
+          details: errors.array()
+        }
+      });
+    }
+
+    const { title, description, due_date } = req.body;
+    const userId = req.user.id;
+
+    const newTodo = await todoService.createTodo({
+      title,
+      description,
+      due_date,
+      user_id: userId
+    });
+
+    logger.info(`Todo created successfully for user ${userId}`);
+
+    res.status(201).json({
+      success: true,
+      data: newTodo
+    });
+  } catch (error) {
+    logger.error('Error creating todo:', error);
+    next(error);
+  }
+};
+
+module.exports = {
+  createTodo
+};

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -1,0 +1,56 @@
+const jwt = require('jsonwebtoken');
+const logger = require('../utils/logger');
+
+const JWT_SECRET = process.env.JWT_SECRET;
+const AUTH_HEADER_PREFIX = 'Bearer ';
+
+/**
+ * Authentication middleware to verify JWT tokens
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Function} next - Express next middleware function
+ */
+const authMiddleware = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+    
+    if (!authHeader || !authHeader.startsWith(AUTH_HEADER_PREFIX)) {
+      return res.status(401).json({
+        success: false,
+        error: {
+          code: 'MISSING_TOKEN',
+          message: 'Authentication token required'
+        }
+      });
+    }
+
+    const token = authHeader.substring(AUTH_HEADER_PREFIX.length);
+    
+    if (!token) {
+      return res.status(401).json({
+        success: false,
+        error: {
+          code: 'INVALID_TOKEN',
+          message: 'Invalid authentication token'
+        }
+      });
+    }
+
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.user = decoded;
+    
+    next();
+  } catch (error) {
+    logger.error('Authentication error:', error);
+    
+    return res.status(401).json({
+      success: false,
+      error: {
+        code: 'TOKEN_VERIFICATION_FAILED',
+        message: 'Invalid or expired authentication token'
+      }
+    });
+  }
+};
+
+module.exports = authMiddleware;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,51 @@
+const logger = require('../utils/logger');
+
+/**
+ * Global error handling middleware
+ * @param {Error} error - Error object
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Function} next - Express next middleware function
+ */
+const errorHandler = (error, req, res, next) => {
+  logger.error('Unhandled error:', {
+    message: error.message,
+    stack: error.stack,
+    url: req.url,
+    method: req.method,
+    ip: req.ip
+  });
+
+  // Database constraint violations
+  if (error.code === '23505') { // PostgreSQL unique violation
+    return res.status(409).json({
+      success: false,
+      error: {
+        code: 'DUPLICATE_RESOURCE',
+        message: 'Resource already exists'
+      }
+    });
+  }
+
+  // Database connection errors
+  if (error.code === 'ECONNREFUSED' || error.code === 'ENOTFOUND') {
+    return res.status(503).json({
+      success: false,
+      error: {
+        code: 'DATABASE_UNAVAILABLE',
+        message: 'Service temporarily unavailable'
+      }
+    });
+  }
+
+  // Default server error
+  res.status(500).json({
+    success: false,
+    error: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unexpected error occurred'
+    }
+  });
+};
+
+module.exports = errorHandler;

--- a/src/repositories/todoRepository.js
+++ b/src/repositories/todoRepository.js
@@ -1,0 +1,46 @@
+const pool = require('../config/database');
+const logger = require('../utils/logger');
+
+/**
+ * Creates a new todo record in the database
+ * @param {Object} todoData - Todo data to insert
+ * @returns {Promise<Object>} Created todo object with generated ID
+ */
+const create = async (todoData) => {
+  const client = await pool.connect();
+  
+  try {
+    const query = `
+      INSERT INTO todos (title, description, due_date, status, user_id, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      RETURNING id, title, description, due_date, status, user_id, created_at, updated_at
+    `;
+    
+    const values = [
+      todoData.title,
+      todoData.description || null,
+      todoData.due_date || null,
+      todoData.status,
+      todoData.user_id,
+      todoData.created_at,
+      todoData.updated_at
+    ];
+
+    const result = await client.query(query, values);
+    
+    if (result.rows.length === 0) {
+      throw new Error('Failed to create todo record');
+    }
+
+    return result.rows[0];
+  } catch (error) {
+    logger.error('Database error in todoRepository.create:', error);
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+module.exports = {
+  create
+};

--- a/src/routes/todoRoutes.js
+++ b/src/routes/todoRoutes.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const { body } = require('express-validator');
+const todoController = require('../controllers/todoController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+// Validation rules for todo creation
+const createTodoValidation = [
+  body('title')
+    .notEmpty()
+    .withMessage('Title is required')
+    .isString()
+    .withMessage('Title must be a string')
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage('Title must be between 1 and 255 characters'),
+  body('description')
+    .optional()
+    .isString()
+    .withMessage('Description must be a string')
+    .trim(),
+  body('due_date')
+    .optional()
+    .isISO8601()
+    .withMessage('Due date must be in valid ISO 8601 format')
+];
+
+/**
+ * POST /api/todos - Create a new todo
+ * Requires authentication and validates input
+ */
+router.post('/', authMiddleware, createTodoValidation, todoController.createTodo);
+
+module.exports = router;

--- a/src/services/todoService.js
+++ b/src/services/todoService.js
@@ -1,0 +1,37 @@
+const todoRepository = require('../repositories/todoRepository');
+const logger = require('../utils/logger');
+
+// Default status for new todos
+const DEFAULT_STATUS = 'open';
+
+/**
+ * Creates a new todo item for a user
+ * @param {Object} todoData - Todo creation data
+ * @param {string} todoData.title - Todo title (required)
+ * @param {string} todoData.description - Todo description
+ * @param {string} todoData.due_date - Due date in ISO format
+ * @param {number} todoData.user_id - ID of the user creating the todo
+ * @returns {Promise<Object>} Created todo object with generated ID
+ */
+const createTodo = async (todoData) => {
+  try {
+    const todoWithDefaults = {
+      ...todoData,
+      status: DEFAULT_STATUS,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    };
+
+    const createdTodo = await todoRepository.create(todoWithDefaults);
+    
+    logger.info(`Todo created with ID: ${createdTodo.id}`);
+    return createdTodo;
+  } catch (error) {
+    logger.error('Error in todoService.createTodo:', error);
+    throw error;
+  }
+};
+
+module.exports = {
+  createTodo
+};


### PR DESCRIPTION
## Summary
Implements POST /api/todos endpoint with JWT authentication, input validation, and database persistence. Creates todos with default 'open' status and associates them with authenticated users.

## Linked Issue
Closes #407

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-001 | ✅ | POST endpoint accepts title, description, due_date with JWT auth middleware validation |
| AC-002 | ✅ | Returns 201 status with complete todo data including database-generated ID |
| AC-003 | ✅ | Todo service sets default status to 'open' for all new todos |
| AC-004 | ✅ | Auth middleware returns 401 for missing/invalid JWT tokens |
| AC-005 | ✅ | Express-validator middleware returns 400 for missing title field |

## Notes for Reviewer
Uses layered architecture (controller-service-repository) as specified in ADR-002. JWT authentication requires JWT_SECRET environment variable. Database pool connection assumes PostgreSQL setup per ADR-001.

