### PR TITLE
feat: Task 23 - Implement todo deletion endpoint

### DIFF
--- a/src/constants/httpStatus.js
+++ b/src/constants/httpStatus.js
@@ -1,0 +1,16 @@
+/**
+ * HTTP status code constants
+ */
+const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500
+};
+
+module.exports = { HTTP_STATUS };

--- a/src/controllers/todoController.js
+++ b/src/controllers/todoController.js
@@ -1,0 +1,32 @@
+const todoService = require('../services/todoService');
+const { AppError } = require('../utils/errors');
+const { HTTP_STATUS } = require('../constants/httpStatus');
+
+/**
+ * Handles HTTP requests for todo operations
+ */
+class TodoController {
+  /**
+   * Deletes a todo item by ID with ownership validation
+   * @param {Object} req - Express request object
+   * @param {Object} res - Express response object
+   * @param {Function} next - Express next middleware function
+   */
+  async deleteTodo(req, res, next) {
+    try {
+      const todoId = parseInt(req.params.id, 10);
+      const userId = req.user.id;
+
+      if (isNaN(todoId)) {
+        throw new AppError('Invalid todo ID', HTTP_STATUS.BAD_REQUEST);
+      }
+
+      await todoService.deleteTodo(todoId, userId);
+      res.status(HTTP_STATUS.NO_CONTENT).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = new TodoController();

--- a/src/repositories/todoRepository.js
+++ b/src/repositories/todoRepository.js
@@ -1,0 +1,39 @@
+const db = require('../config/database');
+const { DatabaseError } = require('../utils/errors');
+
+/**
+ * Data access layer for todo operations
+ */
+class TodoRepository {
+  /**
+   * Finds a todo by its ID
+   * @param {number} id - The todo ID to search for
+   * @returns {Promise<Object|null>} Todo object or null if not found
+   * @throws {DatabaseError} When database operation fails
+   */
+  async findById(id) {
+    try {
+      const query = 'SELECT id, title, description, completed, user_id, created_at, updated_at FROM todos WHERE id = $1';
+      const result = await db.query(query, [id]);
+      return result.rows[0] || null;
+    } catch (error) {
+      throw new DatabaseError('Failed to find todo', error);
+    }
+  }
+
+  /**
+   * Deletes a todo by its ID
+   * @param {number} id - The todo ID to delete
+   * @throws {DatabaseError} When database operation fails
+   */
+  async deleteById(id) {
+    try {
+      const query = 'DELETE FROM todos WHERE id = $1';
+      await db.query(query, [id]);
+    } catch (error) {
+      throw new DatabaseError('Failed to delete todo', error);
+    }
+  }
+}
+
+module.exports = new TodoRepository();

--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const todoController = require('../controllers/todoController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+/**
+ * DELETE /api/todos/:id - Delete a todo item
+ * Requires authentication and validates ownership
+ */
+router.delete('/:id', authMiddleware.authenticate, todoController.deleteTodo);
+
+module.exports = router;

--- a/src/services/todoService.js
+++ b/src/services/todoService.js
@@ -1,0 +1,30 @@
+const todoRepository = require('../repositories/todoRepository');
+const { AppError } = require('../utils/errors');
+const { HTTP_STATUS } = require('../constants/httpStatus');
+
+/**
+ * Service layer for todo business logic
+ */
+class TodoService {
+  /**
+   * Deletes a todo item after validating ownership
+   * @param {number} todoId - The ID of the todo to delete
+   * @param {number} userId - The ID of the requesting user
+   * @throws {AppError} When todo not found or access denied
+   */
+  async deleteTodo(todoId, userId) {
+    const todo = await todoRepository.findById(todoId);
+    
+    if (!todo) {
+      throw new AppError('Todo not found', HTTP_STATUS.NOT_FOUND);
+    }
+
+    if (todo.user_id !== userId) {
+      throw new AppError('Access denied', HTTP_STATUS.FORBIDDEN);
+    }
+
+    await todoRepository.deleteById(todoId);
+  }
+}
+
+module.exports = new TodoService();

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,35 @@
+/**
+ * Custom application error class
+ */
+class AppError extends Error {
+  /**
+   * Creates an application error
+   * @param {string} message - Error message
+   * @param {number} statusCode - HTTP status code
+   */
+  constructor(message, statusCode) {
+    super(message);
+    this.statusCode = statusCode;
+    this.isOperational = true;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * Database operation error class
+ */
+class DatabaseError extends Error {
+  /**
+   * Creates a database error
+   * @param {string} message - Error message
+   * @param {Error} originalError - Original database error
+   */
+  constructor(message, originalError) {
+    super(message);
+    this.originalError = originalError;
+    this.isOperational = true;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = { AppError, DatabaseError };


### PR DESCRIPTION
## Summary
Implements DELETE /api/todos/:id endpoint that allows authenticated users to delete their own todo items with proper ownership validation. Returns 204 on success, 404 for non-existent todos, 403 for unauthorized access, and 401 for missing authentication.

## Linked Issue
Closes #413

## Acceptance Criteria Coverage
| AC ID | Addressed? | How |
|-------|-----------|-----|
| AC-001 | ✅ | Controller returns 204 No Content status on successful deletion |
| AC-002 | ✅ | Service throws 404 AppError when todo is not found in database |
| AC-003 | ✅ | Service validates todo.user_id matches requesting user ID, throws 403 if mismatch |
| AC-004 | ✅ | Route uses authMiddleware.authenticate which handles 401 for missing/invalid tokens |

## Notes for Reviewer
Implementation follows layered architecture pattern with controller-service-repository separation. All database operations use parameterized queries to prevent SQL injection. Error handling catches and re-throws with appropriate HTTP status codes.

